### PR TITLE
Select devices in menu

### DIFF
--- a/App/DeviceHotKey.cs
+++ b/App/DeviceHotKey.cs
@@ -1,3 +1,62 @@
-﻿namespace AudioSwitch.App;
+﻿using AudioSwitch.Enum;
+using AudioSwitch.Extensions;
+using AudioSwitch.Services;
+using AudioSwitch.Utils;
 
-public record DeviceHotKey(string DeviceName, uint Modifiers, Keys Key, int Id);
+namespace AudioSwitch.App;
+
+public class DeviceHotKey
+{
+    public string DeviceName { get; }
+    public Keys Shortcut { get; private set; }
+    public int Id { get; }
+
+    public DeviceHotKey(string deviceName, Keys shortcut, int id)
+    {
+        DeviceName = deviceName;
+        Shortcut = shortcut;
+        Id = id;
+    }
+
+    public uint GetModifiers()
+    {
+        return Shortcut.GetModifiers().AsUint();
+    }
+
+    public uint GetKey()
+    {
+        return Shortcut.GetKey().AsUint();
+    }
+
+    /// <summary>
+    /// Change the device shortcut.
+    /// If registering new shortcut fails, attempt to revert to the existing.
+    /// If reverting fails, clear the shortcut.
+    /// </summary>
+    /// <param name="handle">The form handle to register the shortcut against</param>
+    /// <param name="newShortcut">The new shortcut</param>
+    /// <returns>Return code</returns>
+    public Return ChangeShortcut(IntPtr handle, Keys newShortcut)
+    {
+        try
+        {
+            var previousShortcut = Shortcut;
+            HotKeys.UnregisterHotKey(handle, this);
+            Shortcut = newShortcut;
+            var success = HotKeys.RegisterHotKey(handle, this);
+            if (success) return Return.Success;
+            Shortcut = previousShortcut;
+            var revertSuccess = HotKeys.RegisterHotKey(handle, this);
+            if (!revertSuccess)
+            {
+                Shortcut = 0u;
+            }
+
+            return revertSuccess ? Return.Noop : Return.Failure;
+        }
+        finally
+        {
+            SettingsService.Save();
+        }
+    }
+}

--- a/App/TrayAppContext.cs
+++ b/App/TrayAppContext.cs
@@ -1,5 +1,4 @@
-﻿using AudioSwitch.Enum;
-using AudioSwitch.Extensions;
+﻿using AudioSwitch.Components;
 using AudioSwitch.Forms;
 using AudioSwitch.Services;
 using AudioSwitch.Utils;
@@ -24,7 +23,7 @@ public class TrayAppContext : ApplicationContext
         {
             Icon = new Icon("Resources/audioswitch.ico"),
             Visible = true,
-            Text = $"AudioSwitch",
+            Text = Constants.AppName,
             ContextMenuStrip = new ContextMenuStrip
             {
                 BackColor = Color.White,

--- a/App/TrayAppContext.cs
+++ b/App/TrayAppContext.cs
@@ -12,6 +12,7 @@ public class TrayAppContext : ApplicationContext
 {
     private readonly NotifyIcon _trayIcon;
     private readonly CoreAudioController _audioController = new();
+    private readonly List<ToolStripItem> _deviceButtons = new();
 
     public TrayAppContext()
     {
@@ -35,52 +36,29 @@ public class TrayAppContext : ApplicationContext
 
         foreach (var device in SettingsService.Settings.DeviceHotKeys)
         {
-            _trayIcon.ContextMenuStrip.Items.Add(CreateDescriptivePanelFromDevice(device));
-            _trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
+            // device.ChangeShortcut(dummyForm.Handle,
+            //     Keys.Control | Keys.Shift | Keys.Alt | (device.DeviceName.StartsWith("Speak")
+            //         ? Keys.OemCloseBrackets
+            //         : Keys.OemOpenBrackets));
+            
+            _deviceButtons.Add(GetDeviceButton(device));
         }
 
+        
+        _trayIcon.ContextMenuStrip.Items.AddRange(_deviceButtons.ToArray());
+        _trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
         _trayIcon.ContextMenuStrip.Items.Add(GetDarkModeToggle());
         _trayIcon.ContextMenuStrip.Items.Add(GetExitButton(dummyForm.Handle));
         _trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
         _trayIcon.ContextMenuStrip.Items.Add(GetVersionItem());
     }
 
-    private static ToolStripItem CreateDescriptivePanelFromDevice(DeviceHotKey device)
+    private ToolStripMenuItem GetDeviceButton(DeviceHotKey device)
     {
-        var panel = new Panel
+        return new DeviceMenuItem(device, (s, e) =>
         {
-            BackColor = Color.Transparent,
-            Padding = new Padding(4),
-            AutoSize = true,
-        };
-
-        var titleLabel = new Label
-        {
-            Text = device.DeviceName,
-            AutoSize = true,
-        };
-        var modString = ((ModifierKeys)device.Modifiers).ToModifierString();
-        var moddedString = modString.Length == 0 ? string.Empty : $"{modString}+";
-        var key = device.Key.ToSymbol();
-        var descLabel = new Label
-        {
-            Text = $"{moddedString}{key}",
-            Font = new Font("Segoe UI", 8),
-            ForeColor = SystemColors.GrayText,
-            AutoSize = true
-        };
-
-        panel.Controls.Add(titleLabel);
-        panel.Controls.Add(descLabel);
-        descLabel.Top = titleLabel.Bottom + 2;
-
-        return new ToolStripControlHost(panel)
-        {
-            Margin = Padding.Empty,
-            Padding = Padding.Empty,
-            AutoSize = true,
-            Size = panel.PreferredSize,
-        };
+            _ = SwitchTo(device.DeviceName);
+        });
     }
 
     private static ToolStripMenuItem GetDarkModeToggle()

--- a/App/TrayAppContext.cs
+++ b/App/TrayAppContext.cs
@@ -17,8 +17,7 @@ public class TrayAppContext : ApplicationContext
     public TrayAppContext()
     {
         var dummyForm = new HiddenForm();
-        HotKeys.RegisterMultipleHotKeys(dummyForm.Handle, SettingsService.Settings.DeviceHotKeys);
-
+        HotKeys.RegisterHotKeys(dummyForm.Handle, SettingsService.Settings.DeviceHotKeys);
         dummyForm.HotKeyPressed += OnHotKeyPressed;
 
         _trayIcon = new NotifyIcon
@@ -79,7 +78,7 @@ public class TrayAppContext : ApplicationContext
     {
         return new ToolStripMenuItem("Exit", null, (s, e) =>
         {
-            HotKeys.UnregisterMultipleHotKeys(handle, SettingsService.Settings.DeviceHotKeys);
+            HotKeys.UnregisterHotKeys(handle, SettingsService.Settings.DeviceHotKeys);
             _trayIcon.Visible = false;
             _trayIcon.Dispose();
             Application.Exit();

--- a/AudioSwitch.csproj
+++ b/AudioSwitch.csproj
@@ -16,13 +16,21 @@
         <PublishSingleFile>true</PublishSingleFile>
         <IncludeNativeLibrariesForSelfExtract>false</IncludeNativeLibrariesForSelfExtract>
         <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
-        <DebugType>none</DebugType>
-        <DebugSymbols>false</DebugSymbols>
 
         <!-- versioning -->
         <AssemblyVersion>1.3.0.0</AssemblyVersion>
         <FileVersion>1.3.0.0</FileVersion>
         <InformationalVersion>1.3.0</InformationalVersion>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <DebugType>portable</DebugType>
+        <DebugSymbols>true</DebugSymbols>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <DebugType>none</DebugType>
+        <DebugSymbols>false</DebugSymbols>
     </PropertyGroup>
 
     <ItemGroup>

--- a/AudioSwitch.csproj
+++ b/AudioSwitch.csproj
@@ -20,9 +20,9 @@
         <DebugSymbols>false</DebugSymbols>
 
         <!-- versioning -->
-        <AssemblyVersion>1.2.1.0</AssemblyVersion>
-        <FileVersion>1.2.1.0</FileVersion>
-        <InformationalVersion>1.2.1</InformationalVersion>
+        <AssemblyVersion>1.3.0.0</AssemblyVersion>
+        <FileVersion>1.3.0.0</FileVersion>
+        <InformationalVersion>1.3.0</InformationalVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Components/DeviceMenuItem.cs
+++ b/Components/DeviceMenuItem.cs
@@ -1,0 +1,15 @@
+﻿using AudioSwitch.App;
+using AudioSwitch.Extensions;
+
+namespace AudioSwitch.Components;
+
+public class DeviceMenuItem : ToolStripMenuItem
+{
+
+    public DeviceMenuItem(DeviceHotKey device, EventHandler onClick) : base(device.DeviceName, null, onClick)
+    {
+        ShowShortcutKeys = true;
+        ShortcutKeys = device.Shortcut;
+        ShortcutKeyDisplayString = device.Shortcut.ToDisplayString();
+    }
+}

--- a/Constants.cs
+++ b/Constants.cs
@@ -2,5 +2,6 @@
 
 public static class Constants
 {
-    public static readonly string AppName = "com.jonnyreading.audioswitch";
+    public const string AppIdentifier = "com.jonnyreading.audioswitch";
+    public const string AppName = "AudioSwitch";
 }

--- a/Enum/ModifierKeys.cs
+++ b/Enum/ModifierKeys.cs
@@ -6,5 +6,4 @@ public enum ModifierKeys : uint
     Alt = 0x001,
     Control = 0x002,
     Shift = 0x004,
-    Win = 0x008,
 }

--- a/Enum/Return.cs
+++ b/Enum/Return.cs
@@ -1,0 +1,8 @@
+﻿namespace AudioSwitch.Enum;
+
+public enum Return
+{
+    Success = 0,
+    Noop = 1,
+    Failure = 2,
+}

--- a/Extensions/HotKeysExtensions.cs
+++ b/Extensions/HotKeysExtensions.cs
@@ -1,24 +1,87 @@
-﻿using AudioSwitch.Enum;
-using AudioSwitch.Utils;
+﻿using System.Runtime.InteropServices;
+using System.Text;
+using AudioSwitch.Enum;
 
 namespace AudioSwitch.Extensions;
 
 public static class HotKeysExtensions
 {
-    public static string ToSymbol(this Keys key)
+    #region External
+
+    private const string Dll = "user32.dll";
+
+    [DllImport(Dll)]
+    private static extern int ToUnicode(
+        uint wVirtKey,
+        uint wScanCode,
+        byte[] lpKeyState,
+        [Out, MarshalAs(UnmanagedType.LPWStr, SizeParamIndex = 4)]
+        StringBuilder pwszBuff,
+        int cchBuff,
+        uint wFlags);
+
+    [DllImport(Dll)]
+    private static extern bool GetKeyboardState(byte[] lpKeyState);
+
+    [DllImport(Dll)]
+    private static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+    #endregion
+
+    private static string KeysToKeySymbol(Keys key)
     {
-        return HotKeys.KeysToKeySymbol(key);
+        var keyCode = (uint)key;
+        var keyboardState = new byte[256];
+        if (!GetKeyboardState(keyboardState)) return string.Empty;
+
+        var sb = new StringBuilder(2);
+        var scanCode = MapVirtualKey(keyCode, 0);
+        var uni = ToUnicode(keyCode, scanCode, keyboardState, sb, sb.Capacity, 0);
+        return uni > 0 ? sb.ToString() : string.Empty;
     }
 
-    public static string ToModifierString(this ModifierKeys keys)
+    public static ModifierKeys GetModifiers(this Keys keys)
+    {
+        ModifierKeys modifiers = 0;
+        var keyModifiers = keys & Keys.Modifiers;
+
+        if (keyModifiers.HasFlag(Keys.Control))
+            modifiers |= ModifierKeys.Control;
+        if (keyModifiers.HasFlag(Keys.Shift))
+            modifiers |= ModifierKeys.Shift;
+        if (keyModifiers.HasFlag(Keys.Alt))
+            modifiers |= ModifierKeys.Alt;
+
+        return modifiers;
+    }
+
+    public static Keys GetKey(this Keys keys)
+    {
+        return keys & Keys.KeyCode;
+    }
+
+    public static uint AsUint(this ModifierKeys modifiers)
+    {
+        return (uint)modifiers;
+    }
+
+    public static uint AsUint(this Keys key)
+    {
+        return (uint)key;
+    }
+
+    public static string ToDisplayString(this Keys keys)
     {
         var parts = new List<string>();
-
-        if (keys.HasFlag(ModifierKeys.Control)) parts.Add("Ctrl");
-        if (keys.HasFlag(ModifierKeys.Alt)) parts.Add("Alt");
-        if (keys.HasFlag(ModifierKeys.Shift)) parts.Add("Shift");
-        if (keys.HasFlag(ModifierKeys.Win)) parts.Add("Win");
-
-        return string.Join('+', parts);
+        var mods = keys & Keys.Modifiers;
+        if (mods.HasFlag(Keys.Control))
+            parts.Add("Ctrl");
+        if (mods.HasFlag(Keys.Shift))
+            parts.Add("Shift");
+        if (mods.HasFlag(Keys.Alt))
+            parts.Add("Alt");
+        var modString = string.Join("+", parts);
+        var key = KeysToKeySymbol(keys.GetKey());
+        return modString.Length == 0 ? key : $"{modString}+{key}";
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -8,7 +8,7 @@ public static class Program
     [STAThread]
     public static void Main()
     {
-        _ = new Mutex(true, Constants.AppName, out var isNewInstance);
+        _ = new Mutex(true, Constants.AppIdentifier, out var isNewInstance);
         if (!isNewInstance)
         {
             Console.WriteLine("Application is already running");
@@ -16,7 +16,6 @@ public static class Program
         }
 
         SettingsService.Load();
-
 
         // To customize application configuration such as set high DPI settings or default font,
         // see https://aka.ms/applicationconfiguration.

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -8,7 +8,7 @@ public static class SettingsService
     public static AppSettings Settings { get; private set; } = null!;
 
     private static readonly string ConfigDir =
-        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Constants.AppName);
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), Constants.AppIdentifier);
 
     private static readonly string ConfigPath = Path.Combine(ConfigDir, "settings.json");
 

--- a/Utils/HotKeys.cs
+++ b/Utils/HotKeys.cs
@@ -1,7 +1,5 @@
 ﻿using System.Runtime.InteropServices;
-using System.Text;
 using AudioSwitch.App;
-using AudioSwitch.Enum;
 
 namespace AudioSwitch.Utils;
 
@@ -17,56 +15,33 @@ public static class HotKeys
     [DllImport(Dll)]
     private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
 
-    [DllImport(Dll)]
-    private static extern int ToUnicode(
-        uint wVirtKey,
-        uint wScanCode,
-        byte[] lpKeyState,
-        [Out, MarshalAs(UnmanagedType.LPWStr, SizeParamIndex = 4)]
-        StringBuilder pwszBuff,
-        int cchBuff,
-        uint wFlags);
-
-    [DllImport(Dll)]
-    private static extern bool GetKeyboardState(byte[] lpKeyState);
-
-    [DllImport(Dll)]
-    private static extern uint MapVirtualKey(uint uCode, uint uMapType);
-
     #endregion
-
-    public static uint Modifiers(params ModifierKeys[] keys)
-    {
-        return keys.Aggregate(0u, (acc, key) => acc | (uint)key);
-    }
 
     public static void RegisterMultipleHotKeys(IntPtr hWnd, List<DeviceHotKey> hotkeys)
     {
         foreach (var hotkey in hotkeys)
         {
-            var success = RegisterHotKey(hWnd, hotkey.Id, hotkey.Modifiers, (uint)hotkey.Key);
+            var success = RegisterHotKey(hWnd, hotkey);
             if (success) continue;
-            throw new ArgumentException($"Failed to register hotkey {hotkey.Key} {hotkey.Modifiers} {hotkey.Id}");
+            throw new ArgumentException($"Failed to register hotkey '{hotkey.Shortcut}' (id: {hotkey.Id})");
         }
+    }
+
+    public static bool RegisterHotKey(IntPtr hWnd, DeviceHotKey hotkey)
+    {
+        return RegisterHotKey(hWnd, hotkey.Id, hotkey.GetModifiers(), hotkey.GetKey());
     }
 
     public static void UnregisterMultipleHotKeys(IntPtr hWnd, List<DeviceHotKey> hotkeys)
     {
         foreach (var hotkey in hotkeys)
         {
-            UnregisterHotKey(hWnd, hotkey.Id);
+            UnregisterHotKey(hWnd, hotkey);
         }
     }
 
-    public static string KeysToKeySymbol(Keys key)
+    public static void UnregisterHotKey(IntPtr hWnd, DeviceHotKey hotkey)
     {
-        var keyCode = (uint)key;
-        var keyboardState = new byte[256];
-        if (!GetKeyboardState(keyboardState)) return string.Empty;
-
-        var sb = new StringBuilder(2);
-        var scanCode = MapVirtualKey(keyCode, 0);
-        var uni = ToUnicode(keyCode, scanCode, keyboardState, sb, sb.Capacity, 0);
-        return uni > 0 ? sb.ToString() : string.Empty;
+        UnregisterHotKey(hWnd, hotkey.Id);
     }
 }

--- a/Utils/HotKeys.cs
+++ b/Utils/HotKeys.cs
@@ -17,7 +17,7 @@ public static class HotKeys
 
     #endregion
 
-    public static void RegisterMultipleHotKeys(IntPtr hWnd, List<DeviceHotKey> hotkeys)
+    public static void RegisterHotKeys(IntPtr hWnd, List<DeviceHotKey> hotkeys)
     {
         foreach (var hotkey in hotkeys)
         {
@@ -32,7 +32,7 @@ public static class HotKeys
         return RegisterHotKey(hWnd, hotkey.Id, hotkey.GetModifiers(), hotkey.GetKey());
     }
 
-    public static void UnregisterMultipleHotKeys(IntPtr hWnd, List<DeviceHotKey> hotkeys)
+    public static void UnregisterHotKeys(IntPtr hWnd, List<DeviceHotKey> hotkeys)
     {
         foreach (var hotkey in hotkeys)
         {


### PR DESCRIPTION
Refactors device to class and unifies modifiers and shortcut key.

Devices (displaying shortcuts) show up in the context menu as buttons, allowing switching between via menu. Checkboxes show active state
n.b. this isn't ideal - changes outwith the app does not update the checkboxes

Shortcuts not stored solely as Keys, with mapping to ModifierKeys for PInvoke calls.

Enables debugging thanks to accidentally killing it previously