### PR TITLE
Add system theme option

### DIFF
--- a/App/AppSettings.cs
+++ b/App/AppSettings.cs
@@ -1,4 +1,5 @@
-﻿using AudioSwitch.Services;
+﻿using AudioSwitch.Enum;
+using AudioSwitch.Services;
 using Newtonsoft.Json;
 
 namespace AudioSwitch.App;
@@ -7,13 +8,13 @@ public class AppSettings
 {
     #region Fields
 
-    private bool _darkMode = true;
+    private Theme _darkMode = Theme.System;
     private List<DeviceHotKey> _deviceHotKeys = new();
     private float _toastOpacity = 0.8f;
     private int _toastDuration = 1_000;
     private bool _disableFade = false;
 
-    public bool DarkMode
+    public Theme DarkMode
     {
         get => _darkMode;
         set => Set(ref _darkMode, value);

--- a/App/AppSettings.cs
+++ b/App/AppSettings.cs
@@ -8,16 +8,16 @@ public class AppSettings
 {
     #region Fields
 
-    private Theme _darkMode = Theme.System;
+    private Theme _appTheme = Theme.System;
     private List<DeviceHotKey> _deviceHotKeys = new();
     private float _toastOpacity = 0.8f;
     private int _toastDuration = 1_000;
     private bool _disableFade = false;
 
-    public Theme DarkMode
+    public Theme AppTheme
     {
-        get => _darkMode;
-        set => Set(ref _darkMode, value);
+        get => _appTheme;
+        set => Set(ref _appTheme, value);
     }
 
     public List<DeviceHotKey> DeviceHotKeys

--- a/App/TrayAppContext.cs
+++ b/App/TrayAppContext.cs
@@ -86,9 +86,9 @@ public class TrayAppContext : ApplicationContext
 
         void UpdateCheckedState()
         {
-            darkOption.Checked = SettingsService.Settings.DarkMode == (Theme)darkOption.Tag;
-            lightOption.Checked = SettingsService.Settings.DarkMode == (Theme)lightOption.Tag;
-            systemOption.Checked = SettingsService.Settings.DarkMode == (Theme)systemOption.Tag;
+            darkOption.Checked = SettingsService.Settings.AppTheme == (Theme)darkOption.Tag;
+            lightOption.Checked = SettingsService.Settings.AppTheme == (Theme)lightOption.Tag;
+            systemOption.Checked = SettingsService.Settings.AppTheme == (Theme)systemOption.Tag;
         }
 
         void ContextMenuStripOpening(object? sender, EventArgs e)
@@ -99,7 +99,7 @@ public class TrayAppContext : ApplicationContext
         void SettingItemClick(object? sender, EventArgs e)
         {
             if (sender is not ToolStripMenuItem { Tag: Theme theme }) return;
-            SettingsService.Settings.DarkMode = theme;
+            SettingsService.Settings.AppTheme = theme;
             UpdateCheckedState();
         }
     }

--- a/App/TrayAppContext.cs
+++ b/App/TrayAppContext.cs
@@ -1,4 +1,5 @@
 ﻿using AudioSwitch.Components;
+using AudioSwitch.Enum;
 using AudioSwitch.Forms;
 using AudioSwitch.Services;
 using AudioSwitch.Utils;
@@ -46,7 +47,7 @@ public class TrayAppContext : ApplicationContext
         
         _trayIcon.ContextMenuStrip.Items.AddRange(_deviceButtons.ToArray());
         _trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
-        _trayIcon.ContextMenuStrip.Items.Add(GetDarkModeToggle());
+        _trayIcon.ContextMenuStrip.Items.Add(GetThemeDropdown());
         _trayIcon.ContextMenuStrip.Items.Add(GetExitButton(dummyForm.Handle));
         _trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
         _trayIcon.ContextMenuStrip.Items.Add(GetVersionItem());
@@ -60,18 +61,45 @@ public class TrayAppContext : ApplicationContext
         });
     }
 
-    private static ToolStripMenuItem GetDarkModeToggle()
+    private ToolStripMenuItem GetThemeDropdown()
     {
-        return new ToolStripMenuItem("Dark Mode", null, (s, e) =>
+        var menu = new ToolStripMenuItem("Theme");
+
+        var darkOption = new ToolStripMenuItem("Dark") { Tag = Theme.Dark };
+        var lightOption = new ToolStripMenuItem("Light") { Tag = Theme.Light };
+        var systemOption = new ToolStripMenuItem("System") { Tag = Theme.System };
+        
+        darkOption.Click += SettingItemClick;
+        lightOption.Click += SettingItemClick;
+        systemOption.Click += SettingItemClick;
+        
+        menu.DropDownItems.Add(darkOption);
+        menu.DropDownItems.Add(lightOption);
+        menu.DropDownItems.Add(systemOption);
+
+        if (_trayIcon.ContextMenuStrip != null)
         {
-            if (s is not ToolStripMenuItem menu) return;
-            SettingsService.Settings.DarkMode = !SettingsService.Settings.DarkMode;
-            menu.Checked = SettingsService.Settings.DarkMode;
-        })
+            _trayIcon.ContextMenuStrip.Opening += ContextMenuStripOpening;
+        }
+
+        return menu;
+
+        void UpdateCheckedState()
         {
-            CheckOnClick = false,
-            Checked = SettingsService.Settings.DarkMode
-        };
+          
+        }
+
+        void ContextMenuStripOpening(object? sender, EventArgs e)
+        {
+            UpdateCheckedState();
+        }
+
+        void SettingItemClick(object? sender, EventArgs e)
+        {
+            if (sender is not ToolStripMenuItem { Tag: Theme theme }) return;
+           
+            UpdateCheckedState();
+        }
     }
 
     private ToolStripMenuItem GetExitButton(IntPtr handle)

--- a/App/TrayAppContext.cs
+++ b/App/TrayAppContext.cs
@@ -86,7 +86,9 @@ public class TrayAppContext : ApplicationContext
 
         void UpdateCheckedState()
         {
-          
+            darkOption.Checked = SettingsService.Settings.DarkMode == (Theme)darkOption.Tag;
+            lightOption.Checked = SettingsService.Settings.DarkMode == (Theme)lightOption.Tag;
+            systemOption.Checked = SettingsService.Settings.DarkMode == (Theme)systemOption.Tag;
         }
 
         void ContextMenuStripOpening(object? sender, EventArgs e)
@@ -97,7 +99,7 @@ public class TrayAppContext : ApplicationContext
         void SettingItemClick(object? sender, EventArgs e)
         {
             if (sender is not ToolStripMenuItem { Tag: Theme theme }) return;
-           
+            SettingsService.Settings.DarkMode = theme;
             UpdateCheckedState();
         }
     }

--- a/AudioSwitch.csproj
+++ b/AudioSwitch.csproj
@@ -18,9 +18,9 @@
         <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
 
         <!-- versioning -->
-        <AssemblyVersion>1.3.0.0</AssemblyVersion>
-        <FileVersion>1.3.0.0</FileVersion>
-        <InformationalVersion>1.3.0</InformationalVersion>
+        <AssemblyVersion>1.3.1.0</AssemblyVersion>
+        <FileVersion>1.3.1.0</FileVersion>
+        <InformationalVersion>1.3.1</InformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/Enum/Theme.cs
+++ b/Enum/Theme.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace AudioSwitch.Enum;
+
+[JsonConverter(typeof(StringEnumConverter))]
+public enum Theme
+{
+    Dark,
+    Light,
+    System
+}

--- a/Forms/ToastForm.cs
+++ b/Forms/ToastForm.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.InteropServices;
 using AudioSwitch.App;
 using AudioSwitch.Services;
+using AudioSwitch.Utils;
 using Timer = System.Windows.Forms.Timer;
 
 namespace AudioSwitch.Forms;
@@ -12,7 +13,7 @@ public partial class ToastForm : Form
     public ToastForm(string message)
     {
         Settings = SettingsService.Settings;
-        var isDarkMode = Settings.DarkMode;
+        var isDarkMode = ThemeUtils.IsDark(Settings.DarkMode);
         FormBorderStyle = FormBorderStyle.None;
         StartPosition = FormStartPosition.Manual;
         Size = new Size(350, 100);

--- a/Forms/ToastForm.cs
+++ b/Forms/ToastForm.cs
@@ -13,7 +13,7 @@ public partial class ToastForm : Form
     public ToastForm(string message)
     {
         Settings = SettingsService.Settings;
-        var isDarkMode = ThemeUtils.IsDark(Settings.DarkMode);
+        var isDarkMode = ThemeUtils.IsDark(Settings.AppTheme);
         FormBorderStyle = FormBorderStyle.None;
         StartPosition = FormStartPosition.Manual;
         Size = new Size(350, 100);

--- a/Utils/ThemeUtils.cs
+++ b/Utils/ThemeUtils.cs
@@ -1,0 +1,28 @@
+﻿using AudioSwitch.Enum;
+using Microsoft.Win32;
+
+namespace AudioSwitch.Utils;
+
+public static class ThemeUtils
+{
+
+    public static bool IsDark(Theme appSetting)
+    {
+        if (appSetting != Theme.System) return appSetting == Theme.Dark;
+        return GetSystemTheme() == Theme.Dark;
+    }
+    
+    private static Theme GetSystemTheme()
+    {
+        const string registryKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+        const string valueName = "SystemUsesLightTheme";
+        
+        using var key = Registry.CurrentUser.OpenSubKey(registryKeyPath);
+        if (key?.GetValue(valueName) is int value)
+        {
+            return value == 0 ?  Theme.Dark : Theme.Light;
+        }
+
+        return Theme.Light;
+    }
+}


### PR DESCRIPTION
Closes #12 

Refactors the appsettings to use an enum for theme
`Light | Dark | System`

Looks up windows registry value for system dark mode. Falls back to light mode if not found.

Context menu toggle changed to dropdown menu with the three options