### PR TITLE
Fix external device change

### DIFF
--- a/App/TrayAppContext.cs
+++ b/App/TrayAppContext.cs
@@ -46,7 +46,7 @@ public class TrayAppContext : ApplicationContext
             _deviceButtons.Add(GetDeviceButton(device));
         }
 
-        _ = CheckDeviceMenuItems();
+        _trayIcon.ContextMenuStrip.Opening += (s, e) => CheckDeviceMenuItems();
 
         _trayIcon.ContextMenuStrip.Items.AddRange(_deviceButtons.ToArray());
         _trayIcon.ContextMenuStrip.Items.Add(new ToolStripSeparator());
@@ -177,7 +177,6 @@ public class TrayAppContext : ApplicationContext
         if (!success) return;
 
         PlayNotificationSound();
-        await CheckDeviceMenuItems();
         await new ToastForm($"Switched to {device.FullName}").ShowToast();
     }
 

--- a/AudioSwitch.csproj
+++ b/AudioSwitch.csproj
@@ -18,9 +18,9 @@
         <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
 
         <!-- versioning -->
-        <AssemblyVersion>1.3.3.0</AssemblyVersion>
-        <FileVersion>1.3.3.0</FileVersion>
-        <InformationalVersion>1.3.3</InformationalVersion>
+        <AssemblyVersion>1.3.4.0</AssemblyVersion>
+        <FileVersion>1.3.4.0</FileVersion>
+        <InformationalVersion>1.3.4</InformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Debug'">


### PR DESCRIPTION
Device checkboxes are now updated whenever the context menu is opening. So changes to the active audio device made outwith the app are now reflected in the checkboxes.

Closes #3 